### PR TITLE
POST attachment as base64

### DIFF
--- a/src/routes/api/send-mail/+server.js
+++ b/src/routes/api/send-mail/+server.js
@@ -47,10 +47,25 @@ export async function POST( { request } ) {
         ],
     };*/
    //sgMail.send(msg);
-   return json({
-    status: 200,
-    body: {
-        message: content,
-    }
-  });
+//   return json({
+//    status: 200,
+//    body: {
+//        message: content,
+//    }
+//  });
+    const msg = {
+        to: "jericho@gucci-gorman.com",
+        from: "jericho@gucci-gorman.com",
+        subject: name,
+        text: codename,
+        attachments: [
+            {
+                content: content.toString('base64'),
+                filename: "test.jpeg",
+                type: "image/jpeg",
+                disposition: "attachment",
+                content_id: "tb_content_id",
+            },
+        ],
+    };
 }


### PR DESCRIPTION
Has some hardcoded stuff to assume the file is a jpeg for testing. Ultimately, that data (filename, MIME type, and content_id(?)) should come from the caller function (can it come from the browser's file browser?)wq